### PR TITLE
Dark dropdown prop

### DIFF
--- a/docs/lib/Components/DropdownsPage.js
+++ b/docs/lib/Components/DropdownsPage.js
@@ -9,7 +9,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownMenu } from 'reactstrap';
+  DropdownMenu,
+  UncontrolledDropdown } from 'reactstrap';
 import SectionTitle from '../UI/SectionTitle';
 import DropdownExample from '../examples/Dropdown';
 import DropdownSizingExample from '../examples/DropdownSizing';
@@ -89,6 +90,7 @@ DropdownToggle.propTypes = {
 DropdownMenu.propTypes = {
   tag: PropTypes.string,
   children: PropTypes.node.isRequired,
+  dark: PropTypes.bool,
   right: PropTypes.bool,
   flip: PropTypes.bool, // default: true,
   className: PropTypes.string,
@@ -145,6 +147,36 @@ DropdownItem.propTypes = {
     <DropdownItem>Another Action</DropdownItem>
     <DropdownItem divider/>
     <DropdownItem>Another Really Really Long Action (Really!)</DropdownItem>
+  </DropdownMenu>
+</Dropdown>`}
+          </PrismCode>
+        </pre>
+        <SectionTitle>Dark dropdowns</SectionTitle>
+        <p>To opt into darker <code>DropdownMenu</code> to match a dark <code>Navbar</code>, add a <code>dark</code> prop to <code>DropdownMenu</code>.</p>
+        <div className="docs-example">
+          <div>
+            <UncontrolledDropdown>
+              <DropdownToggle caret>
+                Dropdown's menu is dark
+              </DropdownToggle>
+              <DropdownMenu dark>
+                <DropdownItem header>Header</DropdownItem>
+                <DropdownItem active>Active Action</DropdownItem>
+                <DropdownItem>Another Action</DropdownItem>
+              </DropdownMenu>
+            </UncontrolledDropdown>
+          </div>
+        </div>
+        <pre>
+          <PrismCode className="language-jsx">
+{`<Dropdown isOpen={this.state.dropdownOpen} toggle={this.toggle}>
+  <DropdownToggle caret>
+    Dropdown's menu is dark
+  </DropdownToggle>
+  <DropdownMenu dark>
+    <DropdownItem header>Header</DropdownItem>
+    <DropdownItem active>Active Action</DropdownItem>
+    <DropdownItem>Another Action</DropdownItem>
   </DropdownMenu>
 </Dropdown>`}
           </PrismCode>

--- a/package.json
+++ b/package.json
@@ -280,7 +280,7 @@
     "@types/react": "^16.9.51",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.4",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "^5.0.0-alpha2",
     "clean-webpack-plugin": "^3.0.0",
     "conventional-changelog-cli": "^2.0.21",
     "conventional-recommended-bump": "^0.3.0",

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -8,6 +8,7 @@ import { mapToCssModules, tagPropType } from './utils';
 const propTypes = {
   tag: tagPropType,
   children: PropTypes.node.isRequired,
+  dark: PropTypes.bool,
   right: PropTypes.bool,
   flip: PropTypes.bool,
   modifiers: PropTypes.object,
@@ -31,14 +32,15 @@ const directionPositionMap = {
   down: 'bottom',
 };
 
-class DropdownMenu extends React.Component { 
+class DropdownMenu extends React.Component {
 
   render() {
-    const { className, cssModule, right, tag, flip, modifiers, persist, positionFixed, ...attrs } = this.props;
+    const { className, cssModule, dark, right, tag, flip, modifiers, persist, positionFixed, ...attrs } = this.props;
     const classes = mapToCssModules(classNames(
       className,
       'dropdown-menu',
       {
+        'dropdown-menu-dark': dark,
         'dropdown-menu-right': right,
         show: this.context.isOpen,
       }

--- a/src/__tests__/DropdownMenu.spec.js
+++ b/src/__tests__/DropdownMenu.spec.js
@@ -192,4 +192,30 @@ describe('DropdownMenu', () => {
     expect(wrapper.childAt(0).hasClass('dropdown-menu')).toBe(true);
     expect(wrapper.getDOMNode().tagName.toLowerCase()).toBe('main');
   });
+
+  it('should not have the class "dropdown-menu-dark" by default', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <DropdownContext.Provider value={{ isOpen, direction, inNavbar }}>
+        <DropdownMenu>
+          <p>Keep it light</p>
+        </DropdownMenu>
+      </DropdownContext.Provider>
+    );
+
+    expect(wrapper.find('.dropdown-menu').hostNodes().hasClass('dropdown-menu-dark')).toBe(false);
+  });
+
+  it('should have the class "dropdown-menu-dark" when dark is true', () => {
+    isOpen = true;
+    const wrapper = mount(
+      <DropdownContext.Provider value={{ isOpen, direction, inNavbar }}>
+        <DropdownMenu dark>
+          <p>Let's go dark</p>
+        </DropdownMenu>
+      </DropdownContext.Provider>
+    );
+
+    expect(wrapper.find('.dropdown-menu').hostNodes().hasClass('dropdown-menu-dark')).toBe(true);
+  });
 });

--- a/types/lib/DropdownMenu.d.ts
+++ b/types/lib/DropdownMenu.d.ts
@@ -5,6 +5,7 @@ import { CSSModule } from './index';
 export interface DropdownMenuProps extends React.HTMLAttributes<HTMLElement> {
   [key: string]: any;
   tag?: React.ElementType;
+  dark?: boolean;
   right?: boolean;
   flip?: boolean;
   modifiers?: Popper.Modifiers;


### PR DESCRIPTION
Add `dark` prop to the `DropdownMenu` to enable adding `.dropdown-menu-dark` class to the menu.

Closes #1 