### PR TITLE
Replace jumbotron classes with utility classes

### DIFF
--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -25,8 +25,10 @@ const Jumbotron = (props) => {
 
   const classes = mapToCssModules(classNames(
     className,
-    'jumbotron',
-    fluid ? 'jumbotron-fluid' : false
+    'bg-light mb-4 py-3 py-sm-5',
+    {
+      'rounded px-3 px-sm-4': !fluid
+    },
   ), cssModule);
 
   return (

--- a/src/__tests__/Jumbotron.spec.js
+++ b/src/__tests__/Jumbotron.spec.js
@@ -16,17 +16,28 @@ describe('Jumbotron', () => {
     expect(wrapper.find('h1').hostNodes().text()).toBe('Hello from h1');
   });
 
-  it('should have class jumbotron', () => {
+  it('should have default classes', () => {
     const wrapper = shallow(<Jumbotron>Hello</Jumbotron>);
 
-    expect(wrapper.hasClass('jumbotron')).toBe(true);
+    expect(wrapper.hasClass('bg-light')).toBe(true);
+    expect(wrapper.hasClass('mb-4')).toBe(true);
+    expect(wrapper.hasClass('py-3')).toBe(true);
+    expect(wrapper.hasClass('py-sm-5')).toBe(true);
+    expect(wrapper.hasClass('rounded')).toBe(true);
+    expect(wrapper.hasClass('px-3')).toBe(true);
+    expect(wrapper.hasClass('px-sm-4')).toBe(true);
   });
 
-  it('should render fluid jumbotron', () => {
+  it('should render fluid with square corners and no x padding', () => {
     const wrapper = shallow(<Jumbotron fluid>Hello</Jumbotron>);
 
-    expect(wrapper.hasClass('jumbotron')).toBe(true);
-    expect(wrapper.hasClass('jumbotron-fluid')).toBe(true);
+    expect(wrapper.hasClass('bg-light')).toBe(true);
+    expect(wrapper.hasClass('mb-4')).toBe(true);
+    expect(wrapper.hasClass('py-3')).toBe(true);
+    expect(wrapper.hasClass('py-sm-5')).toBe(true);
+    expect(wrapper.hasClass('rounded')).toBe(false);
+    expect(wrapper.hasClass('px-3')).toBe(false);
+    expect(wrapper.hasClass('px-sm-4')).toBe(false);
   });
 
   it('should render custom class', () => {


### PR DESCRIPTION
The jumbtron and jumbotron-fluid classes have been removed in bootstrap 5. This change emulates a similar style by using the utility classes. The padding is not exactly a 1-to-1 replacement since the jumbotron x and y paddings did not follow the utility classes styling.

Closes #9 