### PR TITLE
don't render extra close icon for alerts, modal/toast headers

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -71,9 +71,7 @@ function Alert(props) {
   return (
     <Fade {...attributes} {...alertTransition} tag={Tag} className={classes} in={isOpen} role="alert" innerRef={innerRef}>
       {toggle ?
-        <button type="button" className={closeClasses} aria-label={closeAriaLabel} onClick={toggle}>
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" className={closeClasses} aria-label={closeAriaLabel} onClick={toggle} />
         : null}
       {children}
     </Fade>

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -11,7 +11,6 @@ const propTypes = {
   cssModule: PropTypes.object,
   children: PropTypes.node,
   closeAriaLabel: PropTypes.string,
-  charCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   close: PropTypes.object,
 };
 
@@ -19,7 +18,6 @@ const defaultProps = {
   tag: 'h5',
   wrapTag: 'div',
   closeAriaLabel: 'Close',
-  charCode: 215,
 };
 
 const ModalHeader = (props) => {
@@ -32,7 +30,6 @@ const ModalHeader = (props) => {
     tag: Tag,
     wrapTag: WrapTag,
     closeAriaLabel,
-    charCode,
     close,
     ...attributes } = props;
 
@@ -42,11 +39,8 @@ const ModalHeader = (props) => {
   ), cssModule);
 
   if (!close && toggle) {
-    const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
-        <span aria-hidden="true">{closeIcon}</span>
-      </button>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel} />
     );
   }
 

--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -35,7 +35,6 @@ const ToastHeader = (props) => {
     tag: Tag,
     wrapTag: WrapTag,
     closeAriaLabel,
-    charCode,
     close,
     tagClassName,
     icon: iconProp,
@@ -47,11 +46,8 @@ const ToastHeader = (props) => {
   ), cssModule);
 
   if (!close && toggle) {
-    const closeIcon = typeof charCode === 'number' ? String.fromCharCode(charCode) : charCode;
     closeButton = (
-      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel}>
-        <span aria-hidden="true">{closeIcon}</span>
-      </button>
+      <button type="button" onClick={toggle} className={mapToCssModules('btn-close', cssModule)} aria-label={closeAriaLabel} />
     );
   }
 

--- a/src/__tests__/ModalHeader.spec.js
+++ b/src/__tests__/ModalHeader.spec.js
@@ -37,26 +37,4 @@ describe('ModalHeader', () => {
 
     expect(wrapper.type()).toBe('main');
   });
-
-  it('should render close button with custom aria-label', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}} className="other" closeAriaLabel="oseclay">Yo!</ModalHeader>);
-
-    const closeButton = wrapper.find('button.btn-close').first();
-    expect(closeButton.prop('aria-label')).toBe('oseclay');
-  });
-
-  it('should render close button with default icon', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}}>Yo!</ModalHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    const defaultIcon = String.fromCharCode(215);
-    expect(closeButtonIcon.text()).toEqual(defaultIcon);
-  });
-
-  it('should render close button with custom icon', () => {
-    const wrapper = shallow(<ModalHeader toggle={() => {}} charCode={'X'}>Yo!</ModalHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    expect(closeButtonIcon.text()).toEqual('X');
-  });
 });

--- a/src/__tests__/ToastHeader.spec.js
+++ b/src/__tests__/ToastHeader.spec.js
@@ -37,40 +37,4 @@ describe('ToastHeader', () => {
 
     expect(wrapper.type()).toBe('main');
   });
-
-  it('should render close button with custom aria-label', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }} className="other" closeAriaLabel="oseclay">Yo!</ToastHeader>);
-
-    const closeButton = wrapper.find('button.btn-close').first();
-    expect(closeButton.prop('aria-label')).toBe('oseclay');
-  });
-
-  it('should render close button with default icon', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    const defaultIcon = String.fromCharCode(215);
-    expect(closeButtonIcon.text()).toEqual(defaultIcon);
-  });
-
-  it('should render close button with custom icon', () => {
-    const wrapper = shallow(<ToastHeader toggle={() => { }} charCode={'X'}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('button.btn-close span');
-    expect(closeButtonIcon.text()).toEqual('X');
-  });
-
-  it('should render icon with a color', () => {
-    const wrapper = shallow(<ToastHeader icon="primary">Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('svg');
-    expect(closeButtonIcon.hasClass('text-primary')).toBe(true);
-  });
-
-  it('should render a custom icon', () => {
-    const wrapper = shallow(<ToastHeader icon={<span className="my-header">icon</span>}>Yo!</ToastHeader>);
-
-    const closeButtonIcon = wrapper.find('span.my-header');
-    expect(closeButtonIcon.text()).toEqual("icon");
-  });
 });

--- a/types/lib/ToastHeader.d.ts
+++ b/types/lib/ToastHeader.d.ts
@@ -9,7 +9,6 @@ export interface ToastHeaderProps extends React.HTMLAttributes<HTMLElement> {
   toggle?: React.MouseEventHandler<any>;
   icon?: string | React.ReactNode;
   close?: React.ReactNode;
-  charCode?: string | number;
   closeAriaLabel?: string;
 }
 


### PR DESCRIPTION
https://github.com/gthomas-appfolio/reactstrap/issues/34

Breaking changes: Modal and Toast headers no longer support custom close icons since X icon is built in to the bootstrap `btn-close` class.