### PR TITLE
Remove media class

### DIFF
--- a/src/Media.js
+++ b/src/Media.js
@@ -53,16 +53,12 @@ const Media = (props) => {
   const classes = mapToCssModules(classNames(
     className,
     {
-      'media-body': body,
-      'media-heading': heading,
-      'media-left': left,
-      'media-right': right,
-      'media-top': top,
-      'media-bottom': bottom,
-      'media-middle': middle,
-      'media-object': object,
-      'media-list': list,
-      media: !body && !heading && !left && !right && !top && !bottom && !middle && !object && !list,
+      'flex-grow-1': body,
+      'flex-shrink-0': left || right,
+      'align-self-start': top,
+      'align-self-end': bottom,
+      'align-self-center': middle,
+      'd-flex': !body && !heading && !left && !right && !top && !bottom && !middle && !object && !list,
     }
   ), cssModule);
 

--- a/src/__tests__/Media.spec.js
+++ b/src/__tests__/Media.spec.js
@@ -54,55 +54,43 @@ describe('Media', () => {
   it('should render body', () => {
     const wrapper = shallow(<Media body />);
 
-    expect(wrapper.hasClass('media-body')).toBe(true);
-  });
-
-  it('should render heading', () => {
-    const wrapper = shallow(<Media heading />);
-
-    expect(wrapper.hasClass('media-heading')).toBe(true);
+    expect(wrapper.hasClass('flex-grow-1')).toBe(true);
   });
 
   it('should render left', () => {
     const wrapper = shallow(<Media left />);
 
-    expect(wrapper.hasClass('media-left')).toBe(true);
+    expect(wrapper.hasClass('flex-shrink-0')).toBe(true);
   });
 
   it('should render right', () => {
     const wrapper = shallow(<Media right />);
 
-    expect(wrapper.hasClass('media-right')).toBe(true);
+    expect(wrapper.hasClass('flex-shrink-0')).toBe(true);
   });
 
   it('should render top', () => {
     const wrapper = shallow(<Media top />);
 
-    expect(wrapper.hasClass('media-top')).toBe(true);
+    expect(wrapper.hasClass('align-self-start')).toBe(true);
   });
 
   it('should render bottom', () => {
     const wrapper = shallow(<Media bottom />);
 
-    expect(wrapper.hasClass('media-bottom')).toBe(true);
+    expect(wrapper.hasClass('align-self-end')).toBe(true);
   });
 
   it('should render middle', () => {
     const wrapper = shallow(<Media middle />);
 
-    expect(wrapper.hasClass('media-middle')).toBe(true);
-  });
-
-  it('should render object', () => {
-    const wrapper = shallow(<Media object />);
-
-    expect(wrapper.hasClass('media-object')).toBe(true);
+    expect(wrapper.hasClass('align-self-center')).toBe(true);
   });
 
   it('should render media', () => {
     const wrapper = shallow(<Media />);
 
-    expect(wrapper.hasClass('media')).toBe(true);
+    expect(wrapper.hasClass('d-flex')).toBe(true);
   });
 
   it('should render list', () => {
@@ -114,7 +102,6 @@ describe('Media', () => {
       </Media>
     );
 
-    expect(wrapper.hasClass('media-list')).toBe(true);
     expect(wrapper.find({ tag: 'li' }).length).toBe(3);
   });
 


### PR DESCRIPTION
Bootstrap 5 will no longer support the media class, due to the fact that you can replicate it easily with util classes. We will still keep support for the Media component, but switch to using util classes
